### PR TITLE
Nojira/20190220 merge upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased & outstanding issues]
 - Non-https repo url and apt fetching
 
+## [1.6.0] - 2018-11-08
+Updated the run script to provide a better way for users to arbitrarily modify the environment and configurations.
+
+### Added
+- Added prerun.sh support so users can modify the environment and configurations
+- Added appropriate documentation. Thanks to abtreece for the postgres auto config idea!
+
+### Changed
+- Updated the way python_path is built to be more reliable (uses find instead of ls)
+- Updated the postgres integration documentation to include more details, including ssl enabling (required by hosted Heroku postgres)
+
 ## [1.5.0] - 2018-08-27
 External keyservers were becoming an issue for reliability so the Datadog public key has been added to the buildpack. A few updates were made regarding Agent versioning and the documentation was clarified.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased & outstanding issues]
 - Non-https repo url and apt fetching
 
+## [1.6.1] - 2019-02-05
+Fixed the python path generation code. In between 1.6.0 and 1.6.1 the buildpack added trace search configs to the `datadog.yaml` file. This has been removed as support for the `DD_APM_ANALYZED_SPANS` environment variable is directly supported by the Agent.
+
+### Changed
+- Python path generation for embedded python site packages has been fixed.
+
 ## [1.6.0] - 2018-11-08
 Updated the run script to provide a better way for users to arbitrarily modify the environment and configurations.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+## Contributing
+
+This project is open source (Apache 2 License), which means we're happy for you to fork it, but we'd be even more excited to have you contribute back to it.
+
+### Submitting issues
+
+* If you think you've found an issue, please search the [project issues](https://github.com/DataDog/heroku-buildpack-datadog/issues) and the [Troubleshooting](https://datadog.zendesk.com/hc/en-us/sections/200766955-Troubleshooting) section of our [Knowledge base](https://datadog.zendesk.com/hc/en-us) to see if it's known.
+* If you can't find anything useful, please contact our [support team](http://docs.datadoghq.com/help/) and send a flare. To send a flare, you'll need get to your Dyno's command line:
+  ```shell
+  # From your project directory:
+  heroku run bash
+
+  # Once your Dyno has started and you are at the command line, send a flare:
+  agent -c /app/.apt/etc/datadog-agent/datadog.yaml flare
+  ```
+
+  It can also be helpful to send logs from your running dyno:
+  ```shell
+  # Download Datadog Agent logs
+  heroku ps:copy /app/.apt/var/log/datadog/datadog.log --dyno=<YOUR DYNO NAME>
+
+  # Download Datadog Trace Agent logs
+  heroku ps:copy /app/.apt/var/log/datadog/datadog-apm.log --dyno=<YOUR DYNO NAME>
+  ```
+
+* Finally, you can open [a GitHub issue](https://github.com/DataDog/heroku-buildpack-datadog/issues).
+
+### Pull requests
+
+Have you fixed a bug or written a new check and want to share it? Many thanks!
+
+In order to ease/speed up our review, here are some items you can check/improve when submitting your PR:
+
+* Keep it small and focused. Avoid changing too many things at once.
+* Summarize your PR with an explanatory title and a message describing your changes. Cross-reference any related bugs/PRs and provide steps for testing when appropriate.
+* Write meaningful commit messages. The commit message should describe the reason for the change and give extra details that will allow someone later on to understand in 5 seconds the thing you've been working on for a day.
+* Squash your commits. Please rebase your changes on master and squash your commits whenever possible, it keeps history cleaner and it's easier to revert things.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ This project is open source (Apache 2 License), which means we're happy for you 
   agent -c /app/.apt/etc/datadog-agent/datadog.yaml flare
   ```
 
-  It can also be helpful to send logs from your running dyno:
+  It can also be helpful to send logs from your running Dyno:
   ```shell
   # Download Datadog Agent logs
   heroku ps:copy /app/.apt/var/log/datadog/datadog.log --dyno=<YOUR DYNO NAME>
@@ -30,9 +30,9 @@ This project is open source (Apache 2 License), which means we're happy for you 
 
 Have you fixed a bug or written a new check and want to share it? Many thanks!
 
-In order to ease/speed up our review, here are some items you can check/improve when submitting your PR:
+Here are some tips to keep in mind when submitting a PR:
 
 * Keep it small and focused. Avoid changing too many things at once.
 * Summarize your PR with an explanatory title and a message describing your changes. Cross-reference any related bugs/PRs and provide steps for testing when appropriate.
 * Write meaningful commit messages. The commit message should describe the reason for the change and give extra details that will allow someone later on to understand in 5 seconds the thing you've been working on for a day.
-* Squash your commits. Please rebase your changes on master and squash your commits whenever possible, it keeps history cleaner and it's easier to revert things.
+* Rebase your changes on `master` and **squash** your commits whenever possible—it keeps the history clean, and it's easier to revert later if necessary.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,9 @@ This project is open source (Apache 2 License), which means we're happy for you 
 
 ### Submitting issues
 
-* If you think you've found an issue, please search the [project issues](https://github.com/DataDog/heroku-buildpack-datadog/issues) and the [Troubleshooting](https://datadog.zendesk.com/hc/en-us/sections/200766955-Troubleshooting) section of our [Knowledge base](https://datadog.zendesk.com/hc/en-us) to see if it's known.
+* If you think you've found an issue, please search the [project issues](https://github.com/DataDog/heroku-buildpack-datadog/issues) first.
 * If you can't find anything useful, please contact our [support team](http://docs.datadoghq.com/help/) and send a flare. To send a flare, you'll need get to your Dyno's command line:
+
   ```shell
   # From your project directory:
   heroku run bash

--- a/README.md
+++ b/README.md
@@ -42,13 +42,14 @@ In addition to the environment variables shown above, there are a number of othe
 | Setting | Description|
 | --- | --- |
 | `DD_API_KEY` | *Required.* Your API key is available from the [Datadog API integrations](https://app.datadoghq.com/account/settings#api) page. Note that this is the *API* key, not the application key. |
-| `DD_HOSTNAME` | *Deprecated.* **WARNING**: Setting the hostname manually may result in metrics continuity errors. It is recommended that you do *not* set this variable. Because dyno hosts are ephemeral it is recommended that you monitor based on the tags `dynoname` or `appname`. |
+| `DD_HOSTNAME` | **WARNING**: Setting the hostname manually may result in metrics continuity errors. It is strongly recommended that you do *not* set this variable. Because dyno hosts are ephemeral it is recommended that you monitor based on the tags `dynoname` or `appname`. |
 | `DD_DYNO_HOST` | *Optional.* Set to `true` to use the app and dyno name (e.g. `appname.web.1` or `appname.run.1234`) as the hostname. See the [hostname section](#hostname) below for more information. You must enable Heroku Labs Dyno Metadata to use this feature. Defaults to `false`. |
 | `DD_TAGS` | *Optional.* Sets additional tags provided as a comma-delimited string. For example, `heroku config:set DD_TAGS=simple-tag-0,tag-key-1:tag-value-1`. The buildpack automatically adds the tags `dyno` (the dyno name, e.g. `web.1`) and `dynotype` (the type of dyno, e.g `run` or `web`). See the ["Guide to tagging"](http://docs.datadoghq.com/guides/tagging/) for more information. |
 | `DD_HISTOGRAM_PERCENTILES` | *Optional.* Optionally set additional percentiles for your histogram metrics. See the [Histogram percentiles article](https://help.datadoghq.com/hc/en-us/articles/204588979-How-to-graph-percentiles-in-Datadog) for more information. |
 | `DISABLE_DATADOG_AGENT` | *Optional.* When set, the Datadog Agent will not be run. |
 | `DD_APM_ENABLED` | *Optional.* The Datadog Trace Agent (APM) is run by default. Set this to `false` to disable the Trace Agent. |
 | `DD_PROCESS_AGENT` | *Optional.* The Datadog Process Agent is disabled by default. Set this to `true` to enable the Process Agent. |
+| `DD_SITE` | *Optional.* If you use the app.datadoghq.eu service, set this to `datadoghq.eu`. Defaults to `datadoghq.com`. |
 | `DD_AGENT_VERSION` | *Optional.* By default, the buildpack installs the latest version of the Datadog Agent available in the package repository. Use this variable to install older versions of the Datadog Agent (note that not all versions of the Agent may be available). |
 | `DD_SERVICE_ENV` | *Optional.* The Datadog Agent automatically tries to identify your environment by searching for a tag in the form `env:<environment name>`. For more information, see the [Datadog Tracing environments page](https://docs.datadoghq.com/tracing/environments/). |
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,12 @@ In addition to the environment variables shown above, there are a number of othe
 | Setting                      | Description|
 | ---------------------------- | ------------------------------ |
 | `DD_API_KEY`                 | *Required.* Your API key is available from the [Datadog API Integrations][4] page. Note that this is the *API* key, not the application key.|
-| `DD_HOSTNAME`                | *Deprecated.* **WARNING**: Setting the hostname manually may result in metrics continuity errors. It is recommended that you do *not* set this variable. Because dyno hosts are ephemeral it is recommended that you monitor based on the tags `dynoname` or `appname`.|
+| `DD_HOSTNAME`                | *Optional.* **WARNING**: Setting the hostname manually may result in metrics continuity errors. It is recommended that you do *not* set this variable. Because dyno hosts are ephemeral it is recommended that you monitor based on the tags `dynoname` or `appname`.|
 | `DD_DYNO_HOST`               | *Optional.* Set to `true` to use the dyno name (e.g. `web.1` or `run.1234`) as the hostname. See the [hostname section](#hostname) below for more information. Defaults to `false`|
 | `DD_TAGS`                    | *Optional.* Sets additional tags provided as a space-delimited string. For example, `heroku config:set DD_TAGS="simple-tag-0 tag-key-1:tag-value-1"`. The buildpack automatically adds the tags `dyno` and `dynohost` which represent the Dyno name (e.g. web.1) and host ID (e.g. 33f232db-7fa7-461e-b623-18e60944f44f) respectively. See the ["Guide to tagging"][5] for more information.|
 | `DD_HISTOGRAM_PERCENTILES`   | *Optional.* Optionally set additional percentiles for your histogram metrics. See [How to graph percentiles][6].|
 | `DISABLE_DATADOG_AGENT`      | *Optional.* When set, the Datadog Agent does not run.|
 | `DD_APM_ENABLED`             | *Optional.* Trace collection is enabled by default. Set this to `false` to disable trace collection.|
-| `DD_SERVICE_ENV`             | *Optional.* The Datadog Agent automatically tries to identify your environment by searching for a tag in the form `env:<environment name>`. For more information, see the [Datadog Tracing environments page][7].|
 | `DD_PROCESS_AGENT`           | *Optional.* The Datadog Process Agent is disabled by default. Set this to `true` to enable the Process Agent.|
 | `DD_SITE`                    | *Optional.* If you use the app.datadoghq.eu service, set this to `datadoghq.eu`. Defaults to `datadoghq.com`.|
 | `DD_APM_ANALYZED_SPANS`      | *Optional.* Enable trace search by setting this to a comma-delimited list of analyzed spans. For example, `<SERVICE_NAME_1>|<OPERATION_NAME_1>: 1, <SERVICE_NAME_2>|<OPERATION_NAME_2>: 1`. For more information, see, [the trace search documentation][8] |
@@ -89,11 +88,11 @@ instances:
     ssl: True
 ```
 
-During the Dyno start up, your YAML files is copied to the appropriate Datadog Agent configuration directories.
+During the Dyno start up, your YAML files are copied to the appropriate Datadog Agent configuration directories.
 
 ## Heroku Log Collection
 
-[See the dedicated guide to send your Heroku logs into Datadog][16]
+[See the dedicated guide to send your Heroku logs to Datadog][16]
 
 ## Prerun script
 
@@ -137,12 +136,11 @@ It is not possible to send logs from Heroku to Datadog using this buildpack.
 Earlier versions of this project were forked from the [miketheman heroku-buildpack-datadog project][14]. It was largely rewritten for Datadog's Agent version 6. Changes and more information can be found in the [changelog][15].
 
 [1]: https://devcenter.heroku.com/articles/buildpacks
-[2]: /libraries
+[2]: https://docs.datadoghq.com/libraries
 [3]: https://app.datadoghq.com/account/settings#api
 [4]: https://app.datadoghq.com/account/settings#api
-[5]: /tagging
+[5]: https://docs.datadoghq.com/tagging
 [6]: /graphing/faq/how-to-graph-percentiles-in-datadog
-[7]: /tracing/environments
 [8]: https://docs.datadoghq.com/tracing/setup/?tab=agent630#trace-search
 [9]: https://docs.datadoghq.com/agent
 [10]: https://docs.datadoghq.com/integrations/postgres

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ In addition to the environment variables shown above, there are a number of othe
 | Setting                      | Description|
 | ---------------------------- | ------------------------------ |
 | `DD_API_KEY`                 | *Required.* Your API key is available from the [Datadog API Integrations][4] page. Note that this is the *API* key, not the application key.|
-| `DD_HOSTNAME`                | *Optional.* **WARNING**: Setting the hostname manually may result in metrics continuity errors. It is recommended that you do *not* set this variable. Because dyno hosts are ephemeral it is recommended that you monitor based on the tags `dynoname` or `appname`.|
-| `DD_DYNO_HOST`               | *Optional.* Set to `true` to use the dyno name (e.g. `web.1` or `run.1234`) as the hostname. See the [hostname section](#hostname) below for more information. Defaults to `false`|
+| `DD_HOSTNAME`                | *Optional.* **WARNING**: Setting the hostname manually may result in metrics continuity errors. It is recommended that you do *not* set this variable. Because Dyno hosts are ephemeral it is recommended that you monitor based on the tags `dynoname` or `appname`.|
+| `DD_DYNO_HOST`               | *Optional.* Set to `true` to use the Dyno name (e.g. `web.1` or `run.1234`) as the hostname. See the [hostname section](#hostname) below for more information. Defaults to `false`|
 | `DD_TAGS`                    | *Optional.* Sets additional tags provided as a space-delimited string. For example, `heroku config:set DD_TAGS="simple-tag-0 tag-key-1:tag-value-1"`. The buildpack automatically adds the tags `dyno` and `dynohost` which represent the Dyno name (e.g. web.1) and host ID (e.g. 33f232db-7fa7-461e-b623-18e60944f44f) respectively. See the ["Guide to tagging"][5] for more information.|
 | `DD_HISTOGRAM_PERCENTILES`   | *Optional.* Optionally set additional percentiles for your histogram metrics. See [How to graph percentiles][6].|
 | `DISABLE_DATADOG_AGENT`      | *Optional.* When set, the Datadog Agent does not run.|
@@ -60,9 +60,9 @@ For additional documentation, refer to the [Datadog Agent documentation][9].
 
 ## Hostname
 
-Heroku dynos are ephemeral—they can move to different host machines whenever new code is deployed, configuration changes are made, or resouce needs/availability changes. This makes Heroku flexible and responsive, but can potentially lead to a high number of reported hosts in Datadog. Datadog bills on a per-host basis, and the buildpack default is to report actual hosts, which can lead to higher than expected costs.
+Heroku Dynos are ephemeral—they can move to different host machines whenever new code is deployed, configuration changes are made, or resouce needs/availability changes. This makes Heroku flexible and responsive, but can potentially lead to a high number of reported hosts in Datadog. Datadog bills on a per-host basis, and the buildpack default is to report actual hosts, which can lead to higher than expected costs.
 
-Depending on your use case, you may want to set your hostname so that hosts are aggregated and report a lower number.  To do this, Set `DD_DYNO_HOST` to `true`. This will cause the Agent to report the hostname as the app and dyno name (e.g. `appname.web.1` or `appname.run.1234`) and your host count will closely match your dyno usage. One drawback is that you may see some metrics continuity errors whenever a dyno is cycled.
+Depending on your use case, you may want to set your hostname so that hosts are aggregated and report a lower number.  To do this, Set `DD_DYNO_HOST` to `true`. This will cause the Agent to report the hostname as the app and Dyno name (e.g. `appname.web.1` or `appname.run.1234`) and your host count will closely match your Dyno usage. One drawback is that you may see some metrics continuity errors whenever a Dyno is cycled.
 
 ## Files Locations
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-Datadog Heroku Buildpack
-========================
+---
+title: Datadog Heroku Buildpack
+kind: documentation
+aliases:
+- /developers/faq/how-do-i-collect-metrics-from-heroku-with-datadog
+---
 
-A [Heroku buildpack](https://devcenter.heroku.com/articles/buildpacks) to add [Datadog](https://www.datadoghq.com) to a Heroku Dyno.
-
-## Usage
-
-This buildpack installs the Datadog Agent in your Heroku Dyno to collect system metrics, custom application metrics and traces. To collect custom application metrics or traces, include the language appropriate [DogStatsD or Datadog APM library](http://docs.datadoghq.com/libraries/) in your application.
+This [Heroku buildpack][1] installs the Datadog Agent in your Heroku Dyno to collect system metrics, custom application metrics, and traces. To collect custom application metrics or traces, include the language appropriate [DogStatsD or Datadog APM library][2] in your application.
 
 ## Installation
 
 To add this buildpack to your project, as well as set the required environment variables:
 
 ```shell
-cd <root of my project>
+cd <HEROKU_PROJECT_ROOT_FOLDER>
 
 # If this is a new Heroku project
 heroku create
@@ -25,35 +25,39 @@ heroku labs:enable runtime-dyno-metadata -a $(heroku apps:info|grep ===|cut -d' 
 
 # Add this buildpack and set your Datadog API key
 heroku buildpacks:add --index 1 https://github.com/DataDog/heroku-buildpack-datadog.git
-heroku config:add DD_API_KEY=<your API key>
+heroku config:add DD_API_KEY=<DATADOG_API_KEY>
 
 # Deploy to Heroku
 git push heroku master
 ```
 
+Replace `<DATADOG_API_KEY>` with your [Datadog API key][3].
+
 Once complete, the Datadog Agent is started automatically when each Dyno starts.
 
-The Datadog Agent provides a listening port on 8125 for statsd/dogstatsd metrics and events. Traces are collected on port 8126.
+The Datadog Agent provides a listening port on `8125` for statsd/dogstatsd metrics and events. Traces are collected on port `8126`.
 
 ## Configuration
 
 In addition to the environment variables shown above, there are a number of others you can set:
 
-| Setting | Description|
-| --- | --- |
-| `DD_API_KEY` | *Required.* Your API key is available from the [Datadog API integrations](https://app.datadoghq.com/account/settings#api) page. Note that this is the *API* key, not the application key. |
-| `DD_HOSTNAME` | **WARNING**: Setting the hostname manually may result in metrics continuity errors. It is strongly recommended that you do *not* set this variable. Because dyno hosts are ephemeral it is recommended that you monitor based on the tags `dynoname` or `appname`. |
-| `DD_DYNO_HOST` | *Optional.* Set to `true` to use the app and dyno name (e.g. `appname.web.1` or `appname.run.1234`) as the hostname. See the [hostname section](#hostname) below for more information. You must enable Heroku Labs Dyno Metadata to use this feature. Defaults to `false`. |
-| `DD_TAGS` | *Optional.* Sets additional tags provided as a comma-delimited string. For example, `heroku config:set DD_TAGS=simple-tag-0,tag-key-1:tag-value-1`. The buildpack automatically adds the tags `dyno` (the dyno name, e.g. `web.1`) and `dynotype` (the type of dyno, e.g `run` or `web`). See the ["Guide to tagging"](http://docs.datadoghq.com/guides/tagging/) for more information. |
-| `DD_HISTOGRAM_PERCENTILES` | *Optional.* Optionally set additional percentiles for your histogram metrics. See the [Histogram percentiles article](https://help.datadoghq.com/hc/en-us/articles/204588979-How-to-graph-percentiles-in-Datadog) for more information. |
-| `DISABLE_DATADOG_AGENT` | *Optional.* When set, the Datadog Agent will not be run. |
-| `DD_APM_ENABLED` | *Optional.* The Datadog Trace Agent (APM) is run by default. Set this to `false` to disable the Trace Agent. |
-| `DD_PROCESS_AGENT` | *Optional.* The Datadog Process Agent is disabled by default. Set this to `true` to enable the Process Agent. |
-| `DD_SITE` | *Optional.* If you use the app.datadoghq.eu service, set this to `datadoghq.eu`. Defaults to `datadoghq.com`. |
-| `DD_APM_ANALYZED_SPANS` | *Optional.* Enable trace search by setting this to a comma-delimited list of analyzed spans. For example, `my-service|http.request, my-service-2|flask.request`. For more information, see, [the trace search documentation](https://docs.datadoghq.com/tracing/setup/?tab=agent630#trace-search) |
-| `DD_AGENT_VERSION` | *Optional.* By default, the buildpack installs the latest version of the Datadog Agent available in the package repository. Use this variable to install older versions of the Datadog Agent (note that not all versions of the Agent may be available). |
 
-For additional documentation, refer to the [Datadog Agent documentation](https://docs.datadoghq.com/agent/).
+| Setting                      | Description|
+| ---------------------------- | ------------------------------ |
+| `DD_API_KEY`                 | *Required.* Your API key is available from the [Datadog API Integrations][4] page. Note that this is the *API* key, not the application key.|
+| `DD_HOSTNAME`                | *Deprecated.* **WARNING**: Setting the hostname manually may result in metrics continuity errors. It is recommended that you do *not* set this variable. Because dyno hosts are ephemeral it is recommended that you monitor based on the tags `dynoname` or `appname`.|
+| `DD_DYNO_HOST`               | *Optional.* Set to `true` to use the dyno name (e.g. `web.1` or `run.1234`) as the hostname. See the [hostname section](#hostname) below for more information. Defaults to `false`|
+| `DD_TAGS`                    | *Optional.* Sets additional tags provided as a space-delimited string. For example, `heroku config:set DD_TAGS="simple-tag-0 tag-key-1:tag-value-1"`. The buildpack automatically adds the tags `dyno` and `dynohost` which represent the Dyno name (e.g. web.1) and host ID (e.g. 33f232db-7fa7-461e-b623-18e60944f44f) respectively. See the ["Guide to tagging"][5] for more information.|
+| `DD_HISTOGRAM_PERCENTILES`   | *Optional.* Optionally set additional percentiles for your histogram metrics. See [How to graph percentiles][6].|
+| `DISABLE_DATADOG_AGENT`      | *Optional.* When set, the Datadog Agent does not run.|
+| `DD_APM_ENABLED`             | *Optional.* Trace collection is enabled by default. Set this to `false` to disable trace collection.|
+| `DD_SERVICE_ENV`             | *Optional.* The Datadog Agent automatically tries to identify your environment by searching for a tag in the form `env:<environment name>`. For more information, see the [Datadog Tracing environments page][7].|
+| `DD_PROCESS_AGENT`           | *Optional.* The Datadog Process Agent is disabled by default. Set this to `true` to enable the Process Agent.|
+| `DD_SITE`                    | *Optional.* If you use the app.datadoghq.eu service, set this to `datadoghq.eu`. Defaults to `datadoghq.com`.|
+| `DD_APM_ANALYZED_SPANS`      | *Optional.* Enable trace search by setting this to a comma-delimited list of analyzed spans. For example, `<SERVICE_NAME_1>|<OPERATION_NAME_1>: 1, <SERVICE_NAME_2>|<OPERATION_NAME_2>: 1`. For more information, see, [the trace search documentation][8] |
+| `DD_AGENT_VERSION`           | *Optional.* By default, the buildpack installs the latest version of the Datadog Agent available in the package repository. Use this variable to install older versions of the Datadog Agent (note that not all versions of the Agent may be available).|
+
+For additional documentation, refer to the [Datadog Agent documentation][9].
 
 ## Hostname
 
@@ -61,13 +65,19 @@ Heroku dynos are ephemeral—they can move to different host machines whenever n
 
 Depending on your use case, you may want to set your hostname so that hosts are aggregated and report a lower number.  To do this, Set `DD_DYNO_HOST` to `true`. This will cause the Agent to report the hostname as the app and dyno name (e.g. `appname.web.1` or `appname.run.1234`) and your host count will closely match your dyno usage. One drawback is that you may see some metrics continuity errors whenever a dyno is cycled.
 
+## Files Locations
+
+- The Datadog Agent is installed at `/app/.apt/opt/datadog-agent`
+- The Datadog Agent configuration files are at `/app/.apt/etc/datadog-agent`
+- The Datadog Agent logs are at `/app/.apt/var/log/datadog`
+
 ## Enabling integrations
 
 You can enable Datadog Agent integrations by including an appropriately named YAML file inside a `datadog/conf.d` directory in the root of your application.
 
-For example, to enable the [PostgreSQL integration](https://docs.datadoghq.com/integrations/postgres/), create a file `/datadog/conf.d/postgres.yaml` in your application containing:
+For example, to enable the [PostgreSQL integration][10], create a file `/datadog/conf.d/postgres.yaml` in your application containing:
 
-```yaml
+```
 init_config:
 
 instances:
@@ -79,7 +89,11 @@ instances:
     ssl: True
 ```
 
-During the Dyno start up, your YAML files will be copied to the appropriate Datadog Agent configuration directories.
+During the Dyno start up, your YAML files is copied to the appropriate Datadog Agent configuration directories.
+
+## Heroku Log Collection
+
+[See the dedicated guide to send your Heroku logs into Datadog][16]
 
 ## Prerun script
 
@@ -110,48 +124,31 @@ fi
 
 ## Unsupported
 
-Heroku buildpacks cannot be used with Docker images. To build a Docker image with Datadog, reference the [Datadog Agent docker files](https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles).
+Heroku buildpacks cannot be used with Docker images. To build a Docker image with Datadog, reference the [Datadog Agent docker files][12].
 
 It is not possible to send logs from Heroku to Datadog using this buildpack.
 
 ## Contributing
 
-This project is open source (Apache 2 License), which means we're happy for you to fork it, but we'd be even more excited to have you contribute back to it.
-
-### Submitting issues
-
-* If you think you've found an issue, please search the [project issues](https://github.com/DataDog/heroku-buildpack-datadog/issues) and the [Troubleshooting](https://datadog.zendesk.com/hc/en-us/sections/200766955-Troubleshooting) section of our [Knowledge base](https://datadog.zendesk.com/hc/en-us) to see if it's known.
-* If you can't find anything useful, please contact our [support team](http://docs.datadoghq.com/help/) and send a flare. To send a flare, you'll need get to your Dyno's command line:
-  ```shell
-  # From your project directory:
-  heroku run bash
-
-  # Once your Dyno has started and you are at the command line, send a flare:
-  agent -c /app/.apt/etc/datadog-agent/datadog.yaml flare
-  ```
-
-  It can also be helpful to send logs from your running dyno:
-  ```shell
-  # Download Datadog Agent logs
-  heroku ps:copy /app/.apt/var/log/datadog/datadog.log --dyno=<YOUR DYNO NAME>
-
-  # Download Datadog Trace Agent logs
-  heroku ps:copy /app/.apt/var/log/datadog/datadog-apm.log --dyno=<YOUR DYNO NAME>
-  ```
-
-* Finally, you can open [a GitHub issue](https://github.com/DataDog/heroku-buildpack-datadog/issues).
-
-### Pull requests
-
-Have you fixed a bug or written a new check and want to share it? Many thanks!
-
-In order to ease/speed up our review, here are some items you can check/improve when submitting your PR:
-
-* Keep it small and focused. Avoid changing too many things at once.
-* Summarize your PR with an explanatory title and a message describing your changes. Cross-reference any related bugs/PRs and provide steps for testing when appropriate.
-* Write meaningful commit messages. The commit message should describe the reason for the change and give extra details that will allow someone later on to understand in 5 seconds the thing you've been working on for a day.
-* Squash your commits. Please rebase your changes on master and squash your commits whenever possible, it keeps history cleaner and it's easier to revert things.
+[See the contributing documentation to learn how to open an issue or PR to the Heroku-buildpack-datadog repository][13]
 
 ## History
 
-Earlier versions of this project were forked from the [miketheman heroku-buildpack-datadog project](https://github.com/miketheman/heroku-buildpack-datadog). It was largely rewritten for Datadog's Agent version 6. Changes and more information can be found in the [changelog](https://github.com/DataDog/heroku-buildpack-datadog/blob/master/CHANGELOG.md).
+Earlier versions of this project were forked from the [miketheman heroku-buildpack-datadog project][14]. It was largely rewritten for Datadog's Agent version 6. Changes and more information can be found in the [changelog][15].
+
+[1]: https://devcenter.heroku.com/articles/buildpacks
+[2]: /libraries
+[3]: https://app.datadoghq.com/account/settings#api
+[4]: https://app.datadoghq.com/account/settings#api
+[5]: /tagging
+[6]: /graphing/faq/how-to-graph-percentiles-in-datadog
+[7]: /tracing/environments
+[8]: https://docs.datadoghq.com/tracing/setup/?tab=agent630#trace-search
+[9]: https://docs.datadoghq.com/agent
+[10]: https://docs.datadoghq.com/integrations/postgres
+[11]: https://devcenter.heroku.com/articles/log-drains#https-drains
+[12]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles
+[13]: https://github.com/DataDog/heroku-buildpack-datadog/blob/master/CONTRIBUTING.md
+[14]: https://github.com/miketheman/heroku-buildpack-datadog
+[15]: https://github.com/DataDog/heroku-buildpack-datadog/blob/master/CHANGELOG.md
+[16]: https://docs.datadoghq.com/logs/guide/collect-heroku-logs

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ The Datadog Agent provides a listening port on `8125` for statsd/dogstatsd metri
 
 In addition to the environment variables shown above, there are a number of others you can set:
 
-
 | Setting                      | Description|
 | ---------------------------- | ------------------------------ |
 | `DD_API_KEY`                 | *Required.* Your API key is available from the [Datadog API Integrations][4] page. Note that this is the *API* key, not the application key.|
@@ -53,7 +52,6 @@ In addition to the environment variables shown above, there are a number of othe
 | `DD_APM_ENABLED`             | *Optional.* Trace collection is enabled by default. Set this to `false` to disable trace collection.|
 | `DD_PROCESS_AGENT`           | *Optional.* The Datadog Process Agent is disabled by default. Set this to `true` to enable the Process Agent.|
 | `DD_SITE`                    | *Optional.* If you use the app.datadoghq.eu service, set this to `datadoghq.eu`. Defaults to `datadoghq.com`.|
-| `DD_APM_ANALYZED_SPANS`      | *Optional.* Enable trace search by setting this to a comma-delimited list of analyzed spans. For example, `<SERVICE_NAME_1>|<OPERATION_NAME_1>: 1, <SERVICE_NAME_2>|<OPERATION_NAME_2>: 1`. For more information, see, [the trace search documentation][8] |
 | `DD_AGENT_VERSION`           | *Optional.* By default, the buildpack installs the latest version of the Datadog Agent available in the package repository. Use this variable to install older versions of the Datadog Agent (note that not all versions of the Agent may be available).|
 
 For additional documentation, refer to the [Datadog Agent documentation][9].

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ In addition to the environment variables shown above, there are a number of othe
 | `DD_APM_ENABLED` | *Optional.* The Datadog Trace Agent (APM) is run by default. Set this to `false` to disable the Trace Agent. |
 | `DD_PROCESS_AGENT` | *Optional.* The Datadog Process Agent is disabled by default. Set this to `true` to enable the Process Agent. |
 | `DD_SITE` | *Optional.* If you use the app.datadoghq.eu service, set this to `datadoghq.eu`. Defaults to `datadoghq.com`. |
+| `DD_APM_ANALYZED_SPANS` | *Optional.* Enable trace search by setting this to a comma-delimited list of analyzed spans. For example, `my-service|http.request, my-service-2|flask.request`. For more information, see, [the trace search documentation](https://docs.datadoghq.com/tracing/setup/?tab=agent630#trace-search) |
 | `DD_AGENT_VERSION` | *Optional.* By default, the buildpack installs the latest version of the Datadog Agent available in the package repository. Use this variable to install older versions of the Datadog Agent (note that not all versions of the Agent may be available). |
 
 For additional documentation, refer to the [Datadog Agent documentation](https://docs.datadoghq.com/agent/).

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ In addition to the environment variables shown above, there are a number of othe
 | `DD_HISTOGRAM_PERCENTILES` | *Optional.* Optionally set additional percentiles for your histogram metrics. See the [Histogram percentiles article](https://help.datadoghq.com/hc/en-us/articles/204588979-How-to-graph-percentiles-in-Datadog) for more information. |
 | `DISABLE_DATADOG_AGENT` | *Optional.* When set, the Datadog Agent will not be run. |
 | `DD_APM_ENABLED` | *Optional.* The Datadog Trace Agent (APM) is run by default. Set this to `false` to disable the Trace Agent. |
+| `DD_PROCESS_AGENT` | *Optional.* The Datadog Process Agent is disabled by default. Set this to `true` to enable the Process Agent. |
 | `DD_AGENT_VERSION` | *Optional.* By default, the buildpack installs the latest version of the Datadog Agent available in the package repository. Use this variable to install older versions of the Datadog Agent (note that not all versions of the Agent may be available). |
 | `DD_SERVICE_ENV` | *Optional.* The Datadog Agent automatically tries to identify your environment by searching for a tag in the form `env:<environment name>`. For more information, see the [Datadog Tracing environments page](https://docs.datadoghq.com/tracing/environments/). |
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ This project is open source (Apache 2 License), which means we're happy for you 
   heroku ps:copy /app/.apt/var/log/datadog/datadog-apm.log --dyno=<YOUR DYNO NAME>
   ```
 
-* Finally, you can open [a Github issue](https://github.com/DataDog/heroku-buildpack-datadog/issues).
+* Finally, you can open [a GitHub issue](https://github.com/DataDog/heroku-buildpack-datadog/issues).
 
 ### Pull requests
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ init_config:
 
 instances:
   - host: <YOUR HOSTNAME>
-    port: 5432
+    port: <YOUR PORT>
     username: <YOUR USERNAME>
     password: <YOUR PASSWORD>
     dbname: <YOUR DBNAME>
@@ -101,6 +101,7 @@ if [ -n "$DATABASE_URL" ]; then
     sed -i "s/<YOUR HOSTNAME>/${BASH_REMATCH[3]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
     sed -i "s/<YOUR USERNAME>/${BASH_REMATCH[1]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
     sed -i "s/<YOUR PASSWORD>/${BASH_REMATCH[2]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
+    sed -i "s/<YOUR PORT>/${BASH_REMATCH[4]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
     sed -i "s/<YOUR DBNAME>/${BASH_REMATCH[5]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
   fi
 fi

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ During the Dyno start up, your YAML files will be copied to the appropriate Data
 
 ## Prerun script
 
-In addition to all of the configurations above, you can include a prerun script, `/datadog/prerun.sh`, in your application to arbitrarily modify the environment variables and configuration files prior to starting the Datadog Agent.
+In addition to all of the configurations above, you can include a prerun script, `/datadog/prerun.sh`, in your application. The prerun script will run after all of the standard configuration actions and immediately before starting the Datadog Agent. This allows you to modify the environment variables, perform additional configurations, or even disable the Datadog Agent programmatically.
 
 The example below demonstrates a few of the things you can do in the `prerun.sh` script:
 

--- a/README.md
+++ b/README.md
@@ -66,15 +66,45 @@ You can enable Datadog Agent integrations by including an appropriately named YA
 
 For example, to enable the [PostgreSQL integration](https://docs.datadoghq.com/integrations/postgres/), create a file `/datadog/conf.d/postgres.yaml` in your application containing:
 
-```
+```yaml
 init_config:
 
 instances:
-  - host: <YOUR POSTGRESQL SERVER HOSTNAME>
+  - host: <YOUR HOSTNAME>
     port: 5432
+    username: <YOUR USERNAME>
+    password: <YOUR PASSWORD>
+    dbname: <YOUR DBNAME>
+    ssl: True
 ```
 
 During the Dyno start up, your YAML files will be copied to the appropriate Datadog Agent configuration directories.
+
+## Prerun script
+
+In addition to all of the configurations above, you can include a prerun script, `/datadog/prerun.sh`, in your application to arbitrarily modify the environment variables and configuration files prior to starting the Datadog Agent.
+
+The example below demonstrates a few of the things you can do in the `prerun.sh` script:
+
+```shell
+#!/usr/bin/env bash
+
+# Disable the Datadog Agent based on Dyno type
+if [ "$DYNOTYPE" == "run" ]; then
+  DISABLE_DATADOG_AGENT="true"
+fi
+
+# Update the Postgres configuration from above using the Heroku application environment variable
+if [ -n "$DATABASE_URL" ]; then
+  POSTGREGEX='^postgres://([^:]+):([^@]+)@([^:]+):([^/]+)/(.*)$'
+  if [[ $DATABASE_URL =~ $POSTGREGEX ]]; then
+    sed -i "s/<YOUR HOSTNAME>/${BASH_REMATCH[3]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
+    sed -i "s/<YOUR USERNAME>/${BASH_REMATCH[1]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
+    sed -i "s/<YOUR PASSWORD>/${BASH_REMATCH[2]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
+    sed -i "s/<YOUR DBNAME>/${BASH_REMATCH[5]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
+  fi
+fi
+```
 
 ## Unsupported
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Heroku Dynos are ephemeral—they can move to different host machines whenever n
 
 Depending on your use case, you may want to set your hostname so that hosts are aggregated and report a lower number.  To do this, Set `DD_DYNO_HOST` to `true`. This will cause the Agent to report the hostname as the app and Dyno name (e.g. `appname.web.1` or `appname.run.1234`) and your host count will closely match your Dyno usage. One drawback is that you may see some metrics continuity errors whenever a Dyno is cycled.
 
-## Files Locations
+## File locations
 
 - The Datadog Agent is installed at `/app/.apt/opt/datadog-agent`
 - The Datadog Agent configuration files are at `/app/.apt/etc/datadog-agent`
@@ -88,7 +88,18 @@ instances:
 
 During the Dyno start up, your YAML files are copied to the appropriate Datadog Agent configuration directories.
 
-## Heroku Log Collection
+## Limiting Datadog's console output
+
+In some cases, you may want to limit the amount of logs the Datadog buildpack is writing to the console. 
+
+To limit the log output of the buildpack, set the `DD_LOG_LEVEL` environment variable to one of the following: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL`, `OFF`.
+
+```
+heroku config:add DD_LOG_LEVEL=ERROR
+```
+
+
+## Heroku log collection
 
 [See the dedicated guide to send your Heroku logs to Datadog][16]
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ In addition to the environment variables shown above, there are a number of othe
 | `DD_PROCESS_AGENT` | *Optional.* The Datadog Process Agent is disabled by default. Set this to `true` to enable the Process Agent. |
 | `DD_SITE` | *Optional.* If you use the app.datadoghq.eu service, set this to `datadoghq.eu`. Defaults to `datadoghq.com`. |
 | `DD_AGENT_VERSION` | *Optional.* By default, the buildpack installs the latest version of the Datadog Agent available in the package repository. Use this variable to install older versions of the Datadog Agent (note that not all versions of the Agent may be available). |
-| `DD_SERVICE_ENV` | *Optional.* The Datadog Agent automatically tries to identify your environment by searching for a tag in the form `env:<environment name>`. For more information, see the [Datadog Tracing environments page](https://docs.datadoghq.com/tracing/environments/). |
 
 For additional documentation, refer to the [Datadog Agent documentation](https://docs.datadoghq.com/agent/).
 

--- a/bin/compile
+++ b/bin/compile
@@ -12,10 +12,10 @@ set -o pipefail
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-BUILDPACK_DIR=`cd $(dirname $0); cd ..; pwd`
+BUILDPACK_DIR=$(cd "$(dirname "$0")"; cd ..; pwd)
 
 # Load formating tools
-source $BUILDPACK_DIR/bin/common.sh
+source "$BUILDPACK_DIR/bin/common.sh"
 
 # Setup apt environment
 APT_DIR="$BUILD_DIR/.apt"
@@ -25,9 +25,9 @@ APT_REPO_FILE="$BUILDPACK_DIR/etc/datadog.list"
 APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
 
 # Create build and run environment
-mkdir -p $APT_CACHE_DIR/archives/partial
-mkdir -p $APT_STATE_DIR/lists/partial
-mkdir -p $APT_DIR
+mkdir -p "$APT_CACHE_DIR/archives/partial"
+mkdir -p "$APT_STATE_DIR/lists/partial"
+mkdir -p "$APT_DIR"
 
 # Install dependencies
 topic "Updating apt caches for dependencies"
@@ -36,19 +36,19 @@ apt-get $APT_OPTIONS update | indent
 topic "Installing dependencies"
 DEPS="libpci-dev libpci3 libsensors4 libsensors4-dev libsnmp-base libsnmp30"
 apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommends $DEPS | indent
-IFS=" " read -a DEP_PKGS <<< $DEPS
+IFS=" " read -a DEP_PKGS <<< "$DEPS"
 for DEP in ${DEP_PKGS[@]}; do
   echo "Installing $DEP" | indent
-  ls -t $APT_CACHE_DIR/archives/$DEP\_*.deb | head -1 | xargs -i dpkg -x '{}' $APT_DIR
+  ls -t "$APT_CACHE_DIR"/archives/"$DEP"\_*.deb | head -1 | xargs -i dpkg -x '{}' "$APT_DIR"
 done
 
 # Install GPG key
-topic "Install gpg key for Datadog APT Repository "
+topic "Install gpg key for Datadog APT Repository"
 APT_KEYRING="$CACHE_DIR/apt/trusted.gpg"
 GPG_KEY_FILE="$BUILDPACK_DIR/etc/datadog.gpg"
 GPG_HOME_DIR="$BUILD_DIR/.gnupg"
-mkdir -p $GPG_HOME_DIR
-gpg --ignore-time-conflict --no-options --no-default-keyring --homedir $GPG_HOME_DIR --keyring $APT_KEYRING --import $GPG_KEY_FILE | indent
+mkdir -p "$GPG_HOME_DIR"
+gpg --ignore-time-conflict --no-options --no-default-keyring --homedir "$GPG_HOME_DIR" --keyring "$APT_KEYRING" --import "$GPG_KEY_FILE" | indent
 
 # Install Datadog Agent
 topic "Updating apt caches for Datadog Agent"
@@ -60,33 +60,33 @@ apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommen
 
 # Use specific version if specified.
 DPKG_STUB="$APT_CACHE_DIR/archives/datadog-agent_1%3a"
-if [ -f $ENV_DIR/DD_AGENT_VERSION ]; then
-  DD_AGENT_VERSION=$(cat $ENV_DIR/DD_AGENT_VERSION)
+if [ -f "$ENV_DIR/DD_AGENT_VERSION" ]; then
+  DD_AGENT_VERSION=$(cat "$ENV_DIR/DD_AGENT_VERSION")
   DEB="$DPKG_STUB$DD_AGENT_VERSION.deb"
-  if [ -e $DEB ]; then
+  if [ -e "$DEB" ]; then
     echo "Installing pinned version \"$DD_AGENT_VERSION\"" | indent
   # Stop if we can't find the version.
   else
     topic "ERROR: Version \"$DD_AGENT_VERSION\" was not found."
     echo "Available versions:" | indent
-    for PKG in $DPKG_STUB*.deb; do
-      echo ${PKG:${#DPKG_STUB}:(${#PKG}-${#DPKG_STUB}-4)} | indent
+    for PKG in "$DPKG_STUB"*.deb; do
+      echo "${PKG:${#DPKG_STUB}:(${#PKG}-${#DPKG_STUB}-4)}" | indent
     done
     exit 1
   fi
 else
   echo "No pinned version specified. Installing latest version." | indent
-  DEB=$(ls -t $DPKG_STUB*.deb | head -n 1)
+  DEB=$(ls -t "$DPKG_STUB"*.deb | head -n 1)
   DD_AGENT_VERSION=${DEB:${#DPKG_STUB}:(${#DEB}-${#DPKG_STUB}-4)}
   echo "Latest version is \"$DD_AGENT_VERSION\". To pin this version, run: heroku config:set DD_AGENT_VERSION=$DD_AGENT_VERSION" | indent
 fi
-dpkg -x $DEB $APT_DIR
+dpkg -x "$DEB" "$APT_DIR"
 
 # Rewrite package-config files
-find $APT_DIR -type f -ipath '*/pkgconfig/*.pc' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$APT_DIR"'\1!g'
+find "$APT_DIR" -type f -ipath '*/pkgconfig/*.pc' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$APT_DIR"'\1!g'
 
 # Install the runner
 topic "Installing Datadog runner"
-mkdir -p $BUILD_DIR/.profile.d
-cp $BUILDPACK_DIR/extra/datadog.sh $BUILD_DIR/.profile.d/
-chmod +x $BUILD_DIR/.profile.d/datadog.sh
+mkdir -p "$BUILD_DIR/.profile.d"
+cp "$BUILDPACK_DIR/extra/datadog.sh" "$BUILD_DIR/.profile.d/"
+chmod +x "$BUILD_DIR/.profile.d/datadog.sh"

--- a/etc/datadog.list
+++ b/etc/datadog.list
@@ -1,3 +1,3 @@
 # We're using insecure http here. Eventually we should fix
 # the apt-transport-https issue.
-deb http://apt.datadoghq.com/ stable 6
+deb [trusted=yes] http://apt.datadoghq.com/ stable 6

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -20,25 +20,26 @@ export DD_LOG_FILE="$DD_LOG_DIR/datadog.log"
 DD_APM_LOG="$DD_LOG_DIR/datadog-apm.log"
 
 # Move Datadog config files into place
-cp $DATADOG_CONF.example $DATADOG_CONF
+cp "$DATADOG_CONF.example" "$DATADOG_CONF"
 
 # Update the Datadog conf yaml with the correct conf.d and checks.d
-sed -i -e"s|^.*confd_path:.*$|confd_path: $DD_CONF_DIR/conf.d|" $DATADOG_CONF
-sed -i -e"s|^.*additional_checksd:.*$|additional_checksd: $DD_DIR/checks.d|" $DATADOG_CONF
+sed -i -e"s|^.*confd_path:.*$|confd_path: $DD_CONF_DIR/conf.d|" "$DATADOG_CONF"
+sed -i -e"s|^.*additional_checksd:.*$|additional_checksd: $DD_DIR/checks.d|" "$DATADOG_CONF"
 
 # Include application's datadog configs
-APP_DATADOG_CONF_DIR="/app/datadog/conf.d"
+APP_DATADOG="/app/datadog"
+APP_DATADOG_CONF_DIR="$APP_DATADOG/conf.d"
 
 for file in "$APP_DATADOG_CONF_DIR"/*.yaml; do
   test -e "$file" || continue # avoid errors when glob doesn't match anything
-  filename=$(basename -- "$file")
+  filename="$(basename -- "$file")"
   filename="${filename%.*}"
   mkdir -p "$DD_CONF_DIR/conf.d/${filename}.d"
-  cp $file "$DD_CONF_DIR/conf.d/${filename}.d/conf.yaml"
+  cp "$file" "$DD_CONF_DIR/conf.d/${filename}.d/conf.yaml"
 done
 
 # Add tags to the config file
-DYNOHOST="$( hostname )"
+DYNOHOST="$(hostname )"
 DYNOTYPE=${DYNO%%.*}
 TAGS="tags:\n  - dyno:$DYNO\n  - dynotype:$DYNOTYPE"
 
@@ -48,21 +49,21 @@ fi
 
 # Convert comma delimited tags from env vars to yaml
 if [ -n "$DD_TAGS" ]; then
-  DD_TAGS=$(sed "s/,[ ]\?/\\\n  - /g" <<< $DD_TAGS)
+  DD_TAGS="$(sed "s/,[ ]\?/\\\n  - /g" <<< "$DD_TAGS")"
   TAGS="$TAGS\n  - $DD_TAGS"
   # User set tags are now in YAML, clear the env var.
   export DD_TAGS=""
 fi
 
 # Inject tags after example tags.
-sed -i "s/^#   - role:database$/#   - role:database\n$TAGS/" $DATADOG_CONF
+sed -i "s/^#   - role:database$/#   - role:database\n$TAGS/" "$DATADOG_CONF"
 
 # Uncomment APM configs and add the log file location.
-sed -i -e"s|^# apm_config:$|apm_config:\n    log_file: $DD_APM_LOG|" $DATADOG_CONF
+sed -i -e"s|^# apm_config:$|apm_config:\n    log_file: $DD_APM_LOG|" "$DATADOG_CONF"
 
 # Uncomment the Process Agent configs and enable.
 if [ "$DD_PROCESS_AGENT" == "true" ]; then
-  sed -i -e"s|^# process_config:$|process_config:\n    enabled: $DD_PROCESS_AGENT|" $DATADOG_CONF
+  sed -i -e"s|^# process_config:$|process_config:\n    enabled: true|" "$DATADOG_CONF"
 fi
 
 # For a list of env vars to override datadog.yaml, see:
@@ -76,42 +77,52 @@ fi
 if [ -z "$DD_HOSTNAME" ]; then
   if [ "$DD_DYNO_HOST" == "true" ]; then
     # Set the hostname to dyno name and ensure rfc1123 compliance.
-    HAN=$( echo $HEROKU_APP_NAME | sed -e 's/[^a-zA-Z0-9-]/-/g' -e 's/^-//g' )
+    HAN="$(echo "$HEROKU_APP_NAME" | sed -e 's/[^a-zA-Z0-9-]/-/g' -e 's/^-//g')"
     if [ "$HAN" != "$HEROKU_APP_NAME" ]; then
       echo "WARNING: The appname \"$HEROKU_APP_NAME\" contains invalid characters. Using \"$HAN\" instead."
     fi
 
-    D=$( echo $DYNO | sed -e 's/[^a-zA-Z0-9.-]/-/g' -e 's/^-//g' )
+    D="$(echo "$DYNO" | sed -e 's/[^a-zA-Z0-9.-]/-/g' -e 's/^-//g')"
     export DD_HOSTNAME="$HAN.$D"
   else
     # Set the hostname to the dyno host
-    export DD_HOSTNAME=$( echo $DYNOHOST | sed -e 's/[^a-zA-Z0-9-]/-/g' -e 's/^-//g' )
+    DD_HOSTNAME="$(echo "$DYNOHOST" | sed -e 's/[^a-zA-Z0-9-]/-/g' -e 's/^-//g')"
+    export DD_HOSTNAME
   fi
 else
   # Generate a warning about DD_HOSTNAME deprecation.
   echo "WARNING: DD_HOSTNAME is deprecated. Setting this environment variable may result in metrics errors. To remove it, run: heroku config:unset DD_HOSTNAME"
 fi
 
+# Ensure all check and librariy locations are findable in the Python path.
+DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7"
+# Recursively add packages to python path.
+find "$DD_PYTHONPATH"/embedded/lib/python*/site-packages -type d -exec DD_PYTHONPATH="{}":"$DD_PYTHONPATH" \;
+DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/site-packages:$DD_PYTHONPATH"
+DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/plat-linux2:$DD_PYTHONPATH"
+DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/lib-tk:$DD_PYTHONPATH"
+DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/lib-dynload:$DD_PYTHONPATH"
+DD_PYTHONPATH="$DD_DIR/bin/agent/dist:$DD_PYTHONPATH"
 
+# Give applications a chance to modify env vars prior to running.
+# Note that this can modify existing env vars or perform other actions (e.g. modify the conf file).
+# For more information on variables and other things you may wish to modify, reference this script
+# and the Datadog Agent documentation: https://docs.datadoghq.com/agent
+PRERUN_SCRIPT="$APP_DATADOG/prerun.sh"
+if [ -e "$PRERUN_SCRIPT" ]; then
+  source "$PRERUN_SCRIPT"
+fi
+
+# Execute the final run logic.
 if [ -n "$DISABLE_DATADOG_AGENT" ]; then
   echo "The Datadog Agent has been disabled. Unset the DISABLE_DATADOG_AGENT or set missing environment variables."
 else
-  # Setup Python Path
-  DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7"
-  for python_mod_dir in $(ls -d $DD_DIR/embedded/lib/python*/site-packages 2>/dev/null); do
-    DD_PYTHONPATH="${python_mod_dir}:${DD_PYTHONPATH}"
-  done
-  DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/plat-linux2:$DD_PYTHONPATH"
-  DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/lib-tk:$DD_PYTHONPATH"
-  DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/lib-dynload:$DD_PYTHONPATH"
-  DD_PYTHONPATH="$DD_DIR/bin/agent/dist:$DD_PYTHONPATH"
-
   # Get the Agent version number
-  DD_VERSION=`expr "$($DD_BIN_DIR/agent version)" : 'Agent \([0-9]\+\.[0-9]\+.[0-9]\+\)'`
+  DD_VERSION="$(expr "$($DD_BIN_DIR/agent version)" : 'Agent \([0-9]\+\.[0-9]\+.[0-9]\+\)')"
 
-  # Prior to Agent 2.4.1, the command is "start"
+  # Prior to Agent 6.4.1, the command is "start"
   RUN_VERSION="6.4.1"
-  if [ "$DD_VERSION" == "`echo -e "$RUN_VERSION\n$DD_VERSION" | sort -V | head -n1`" ]; then
+  if [ "$DD_VERSION" == "$(echo -e "$RUN_VERSION\n$DD_VERSION" | sort -V | head -n1)" ]; then
     RUN_COMMAND="start"
   else
     RUN_COMMAND="run"

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -60,6 +60,11 @@ sed -i "s/^#   - role:database$/#   - role:database\n$TAGS/" $DATADOG_CONF
 # Uncomment APM configs and add the log file location.
 sed -i -e"s|^# apm_config:$|apm_config:\n    log_file: $DD_APM_LOG|" $DATADOG_CONF
 
+# Uncomment the Process Agent configs and enable.
+if [ "$DD_PROCESS_AGENT" == "true" ]; then
+  sed -i -e"s|^# process_config:$|process_config:\n    enabled: $DD_PROCESS_AGENT|" $DATADOG_CONF
+fi
+
 # For a list of env vars to override datadog.yaml, see:
 # https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config.go#L145
 

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -61,19 +61,11 @@ sed -i "s/^#   - role:database$/#   - role:database\n$TAGS/" "$DATADOG_CONF"
 # Uncomment APM configs and add the log file location.
 sed -i -e"s|^# apm_config:$|apm_config:|" "$DATADOG_CONF"
 # Add the log file location.
-sed -i -e"s|^apm_config:$|apm_config:\n    log_file: $DD_APM_LOG|" "$DATADOG_CONF"
-
-# If trace search has been added, enable the service names here.
-if [ -n "$DD_APM_ANALYZED_SPANS" ]; then
-  ANALYZED_SPANS="analyzed_spans:"
-  SPANS="$(sed "s/,[ ]\?/: 1\\\n        /g" <<< "$DD_APM_ANALYZED_SPANS")"
-  ANALYZED_SPANS="$ANALYZED_SPANS\n        $SPANS: 1"
-  sed -i "s/^apm_config:$/apm_config:\n    $ANALYZED_SPANS/" $DATADOG_CONF
-fi
+sed -i -e"s|^apm_config:$|apm_config:\n  log_file: $DD_APM_LOG|" "$DATADOG_CONF"
 
 # Uncomment the Process Agent configs and enable.
 if [ "$DD_PROCESS_AGENT" == "true" ]; then
-  sed -i -e"s|^# process_config:$|process_config:\n    enabled: true|" "$DATADOG_CONF"
+  sed -i -e"s|^# process_config:$|process_config:\n  enabled: true|" "$DATADOG_CONF"
 fi
 
 # For a list of env vars to override datadog.yaml, see:

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -59,7 +59,17 @@ fi
 sed -i "s/^#   - role:database$/#   - role:database\n$TAGS/" "$DATADOG_CONF"
 
 # Uncomment APM configs and add the log file location.
-sed -i -e"s|^# apm_config:$|apm_config:\n    log_file: $DD_APM_LOG|" "$DATADOG_CONF"
+sed -i -e"s|^# apm_config:$|apm_config:|" "$DATADOG_CONF"
+# Add the log file location.
+sed -i -e"s|^apm_config:$|apm_config:\n    log_file: $DD_APM_LOG|" "$DATADOG_CONF"
+
+# If trace search has been added, enable the service names here.
+if [ -n "$DD_APM_ANALYZED_SPANS" ]; then
+  ANALYZED_SPANS="analyzed_spans:"
+  SPANS="$(sed "s/,[ ]\?/: 1\\\n        /g" <<< "$DD_APM_ANALYZED_SPANS")"
+  ANALYZED_SPANS="$ANALYZED_SPANS\n        $SPANS: 1"
+  sed -i "s/^apm_config:$/apm_config:\n    $ANALYZED_SPANS/" $DATADOG_CONF
+fi
 
 # Uncomment the Process Agent configs and enable.
 if [ "$DD_PROCESS_AGENT" == "true" ]; then

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -99,8 +99,8 @@ fi
 # Ensure all check and librariy locations are findable in the Python path.
 DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7"
 # Recursively add packages to python path.
-find "$DD_PYTHONPATH"/embedded/lib/python*/site-packages -type d -exec DD_PYTHONPATH="{}":"$DD_PYTHONPATH" \;
-DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/site-packages:$DD_PYTHONPATH"
+DD_PYTHONPATH="$DD_PYTHONPATH:$(find "$DD_DIR/embedded/lib/python2.7/site-packages" -type d -printf ":%p")"
+# Add other packages.
 DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/plat-linux2:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/lib-tk:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/lib-dynload:$DD_PYTHONPATH"


### PR DESCRIPTION
Merge in [upstream master](https://github.com/DataDog/heroku-buildpack-datadog). Left the renderer logic, but this should support https://github.com/DataDog/heroku-buildpack-datadog#prerun-script

Might be worth testing out on a separate app to make sure metrics are still sent to DD. According to the [docs](https://devcenter.heroku.com/articles/buildpacks) we _should_ be able to specify a branch

> You can optionally specify a tag or a branch in the buildpack’s URL (a good safety precaution when using external code):

```bash
heroku buildpacks:set https://github.com/some/buildpack.git#01applications
```

I added this branch as the linked buildpack to `indeedassessments-beta-pr-2871` and it's still reporting metrics, which I think means it worked? https://app.datadoghq.com/dash/host/844237648?live=true&page=0&tile_size=m&is_auto=false&from_ts=1550700540000&to_ts=1550704140000